### PR TITLE
Improved randomizer performance

### DIFF
--- a/src/components/Randomiser.tsx
+++ b/src/components/Randomiser.tsx
@@ -40,10 +40,7 @@ export function flickSlowDown(
   return curPauseDuration;
 }
 
-export type PredictLastFlickOptions<T> = Omit<
-  FlickThroughOptions<T>,
-  'callback' | 'sleepFunc' | 'startDuration'
->;
+export type PredictLastFlickOptions<T> = Omit<FlickThroughOptions<T>, 'callback' | 'sleepFunc'>;
 
 export async function predictLastFlick<T>(
   array: Array<T>,
@@ -75,7 +72,8 @@ export async function flickThroughArray<T>(
   let slowedPauseDuration = pauseDuration;
   let timeSpend = 0;
   let i = 0;
-  for (; timeSpend < duration; i++) {
+
+  while (timeSpend < duration) {
     if (i >= array.length) {
       i = 0;
     }
@@ -96,8 +94,9 @@ export async function flickThroughArray<T>(
     callback(array[i]);
 
     timeSpend += actualPauseDuration;
+    i += 1;
   }
-  return array[i];
+  return array[i - 1];
 }
 
 const Randomiser = ({

--- a/src/components/Randomiser.tsx
+++ b/src/components/Randomiser.tsx
@@ -111,7 +111,6 @@ const Randomiser = ({
 
   useEffect(() => {
     let callback: ((value: string) => void) | undefined = (value: string) => {
-      console.log(value);
       setRandomItem(value);
     };
 

--- a/src/components/Randomiser.tsx
+++ b/src/components/Randomiser.tsx
@@ -20,11 +20,7 @@ async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export function flickSlowDown(
-  curPauseDuration: number,
-  timeSpentTotal: number,
-  startDuration: number
-) {
+function flickSlowDown(curPauseDuration: number, timeSpentTotal: number, startDuration: number) {
   if (curPauseDuration < 0) {
     throw new Error('curPauseDuration should be positive');
   }
@@ -40,9 +36,9 @@ export function flickSlowDown(
   return curPauseDuration;
 }
 
-export type PredictLastFlickOptions<T> = Omit<FlickThroughOptions<T>, 'callback' | 'sleepFunc'>;
+type PredictLastFlickOptions<T> = Omit<FlickThroughOptions<T>, 'callback' | 'sleepFunc'>;
 
-export async function predictLastFlick<T>(
+async function predictLastFlick<T>(
   array: Array<T>,
   { duration, pauseDuration }: PredictLastFlickOptions<T>
 ) {
@@ -54,14 +50,14 @@ export async function predictLastFlick<T>(
   });
 }
 
-export interface FlickThroughOptions<T> {
+interface FlickThroughOptions<T> {
   duration: number;
   pauseDuration: number;
   callback: (value: T) => void;
   sleepFunc?: (ms: number) => Promise<unknown>;
 }
 
-export async function flickThroughArray<T>(
+async function flickThroughArray<T>(
   array: Array<T>,
   { duration, pauseDuration, callback, sleepFunc = sleep }: FlickThroughOptions<T>
 ): Promise<T> {
@@ -129,3 +125,8 @@ const Randomiser = ({
 };
 
 export default Randomiser;
+export const forTestingPurposesOnly = {
+  flickSlowDown,
+  flickThroughArray,
+  predictLastFlick,
+};

--- a/src/components/Randomiser.tsx
+++ b/src/components/Randomiser.tsx
@@ -20,59 +20,84 @@ async function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-async function flickThroughArray<T>(
+export function flickSlowDown(
+  curPauseDuration: number,
+  timeSpentTotal: number,
+  startDuration: number
+) {
+  if (curPauseDuration < 0) {
+    throw new Error('curPauseDuration should be positive');
+  }
+  // Slowdown
+  if (timeSpentTotal >= SLOW_DOWN_THRESHOLD_FRACTION * startDuration) {
+    // this is basically 1/totalTimeLeft so we get an exponential slow down
+    const exponential = SLOW_DOWN_OVER_MULTIPLIER / (startDuration - timeSpentTotal);
+    // We use a multiplier to make these values bigger
+    const addAmount = curPauseDuration * exponential * ITERATION_SLOW_DOWN_MULTIPLIER;
+
+    return curPauseDuration + addAmount;
+  }
+  return curPauseDuration;
+}
+
+export type PredictLastFlickOptions<T> = Omit<
+  FlickThroughOptions<T>,
+  'callback' | 'sleepFunc' | 'startDuration'
+>;
+
+export async function predictLastFlick<T>(
   array: Array<T>,
-  duration: number,
-  pauseDuration: number,
-  callback: (value: T) => void,
-  startDuration?: number
-): Promise<void> {
+  { duration, pauseDuration }: PredictLastFlickOptions<T>
+) {
+  return flickThroughArray(array, {
+    duration,
+    pauseDuration,
+    sleepFunc: () => Promise.resolve(),
+    callback: () => {},
+  });
+}
+
+export interface FlickThroughOptions<T> {
+  duration: number;
+  pauseDuration: number;
+  callback: (value: T) => void;
+  sleepFunc?: (ms: number) => Promise<unknown>;
+}
+
+export async function flickThroughArray<T>(
+  array: Array<T>,
+  { duration, pauseDuration, callback, sleepFunc = sleep }: FlickThroughOptions<T>
+): Promise<T> {
   if (pauseDuration <= 0) {
     throw new Error('pauseDuration must be greater than 0');
   }
 
   let slowedPauseDuration = pauseDuration;
   let timeSpend = 0;
-
-  const actualStartDuration = startDuration ?? duration;
-
-  for (let i = 0; i < array.length; i++) {
+  let i = 0;
+  for (; timeSpend < duration; i++) {
     const timeLeft = duration - timeSpend;
     // We don't want to overshoot
     const actualPauseDuration = Math.min(timeLeft, slowedPauseDuration);
     // the true time we already spent in the loop with recursion
-    const timeSpentTotal = actualStartDuration - duration + timeSpend;
+    const timeSpentTotal = duration - duration + timeSpend;
 
-    if (timeSpend >= duration) {
-      return Promise.resolve();
-    }
+    slowedPauseDuration = flickSlowDown(slowedPauseDuration, timeSpentTotal, duration);
+
     // eslint-disable-next-line no-await-in-loop
-    await sleep(actualPauseDuration);
+    await sleepFunc(actualPauseDuration);
     // Maybe the callback becomes undefined
     // if the component unmounts before the loop is finished
     // In that case we just cancel the flicking
-    if (typeof callback === 'undefined') return Promise.resolve();
+    if (typeof callback === 'undefined') return array[i > 0 ? i - 1 : 0];
     callback(array[i]);
 
-    // Slowdown
-    if (timeSpentTotal >= SLOW_DOWN_THRESHOLD_FRACTION * actualStartDuration) {
-      // this is basically 1/totalTimeLeft so we get an exponential slow down
-      const exponential = SLOW_DOWN_OVER_MULTIPLIER / (actualStartDuration - timeSpentTotal);
-      // We use a multiplier to make these values bigger
-      const addAmount = slowedPauseDuration * exponential * ITERATION_SLOW_DOWN_MULTIPLIER;
-
-      slowedPauseDuration += addAmount;
-    }
-
     timeSpend += actualPauseDuration;
+    if (i >= array.length) {
+      i = 0;
+    }
   }
-  return flickThroughArray(
-    array,
-    duration - timeSpend,
-    slowedPauseDuration,
-    callback,
-    startDuration ?? duration
-  );
+  return array[i];
 }
 
 const Randomiser = ({
@@ -85,15 +110,23 @@ const Randomiser = ({
   const [randomItem, setRandomItem] = useState(randomArray[0]);
 
   useEffect(() => {
-    flickThroughArray(randomArray, duration, pauseDuration, setRandomItem);
+    let callback: ((value: string) => void) | undefined = (value: string) => {
+      setRandomItem(value);
+    };
+
+    flickThroughArray(randomArray, { duration, pauseDuration, callback });
+    // Should return instantly
+    predictLastFlick(randomArray, { duration, pauseDuration }).then((value) => {
+      handleSetItem(value);
+    });
+
+    return () => {
+      callback = undefined;
+    };
   }, []);
 
-  return (
-    <>
-      {handleSetItem(randomItem)}
-      {randomItem}
-    </>
-  );
+  // eslint-disable-next-line react/jsx-no-useless-fragment
+  return <>{randomItem}</>;
 };
 
 export default Randomiser;

--- a/src/components/Randomiser.tsx
+++ b/src/components/Randomiser.tsx
@@ -76,6 +76,9 @@ export async function flickThroughArray<T>(
   let timeSpend = 0;
   let i = 0;
   for (; timeSpend < duration; i++) {
+    if (i >= array.length) {
+      i = 0;
+    }
     const timeLeft = duration - timeSpend;
     // We don't want to overshoot
     const actualPauseDuration = Math.min(timeLeft, slowedPauseDuration);
@@ -89,13 +92,10 @@ export async function flickThroughArray<T>(
     // Maybe the callback becomes undefined
     // if the component unmounts before the loop is finished
     // In that case we just cancel the flicking
-    if (typeof callback === 'undefined') return array[i > 0 ? i - 1 : 0];
+    if (typeof callback === 'undefined') return array[i > 0 ? i - 1 : array.length - 1];
     callback(array[i]);
 
     timeSpend += actualPauseDuration;
-    if (i >= array.length) {
-      i = 0;
-    }
   }
   return array[i];
 }
@@ -111,6 +111,7 @@ const Randomiser = ({
 
   useEffect(() => {
     let callback: ((value: string) => void) | undefined = (value: string) => {
+      console.log(value);
       setRandomItem(value);
     };
 

--- a/test/randomizer/flickThroughArray.test.ts
+++ b/test/randomizer/flickThroughArray.test.ts
@@ -57,6 +57,18 @@ describe('flickThroughArray', () => {
     );
     expect(callback).toBeCalled();
   });
+
+  it('should return the value the last callback recieved', async () => {
+    const array = [1, 2, 3, 4, 5];
+    const duration = 2000;
+    const pauseDuration = 10;
+    const callback = jest.fn<void, [number]>();
+
+    const result = await flickThroughArray(array, { duration, pauseDuration, callback, sleepFunc });
+    expect(callback).toBeCalled();
+    expect(result).toBe(callback.mock.lastCall[0]);
+  });
+
   it('should throw an error if pauseDuration is 0', async () => {
     const array = [1, 2, 3, 4, 5];
     const duration = 200;
@@ -85,5 +97,7 @@ describe('predictLastFlick', () => {
     });
 
     expect(result).toEqual(flickResult);
+    expect(callback).toBeCalled();
+    expect(callback.mock.lastCall[0]).toEqual(flickResult);
   });
 });

--- a/test/randomizer/flickThroughArray.test.ts
+++ b/test/randomizer/flickThroughArray.test.ts
@@ -1,8 +1,6 @@
-import {
-  flickSlowDown,
-  flickThroughArray,
-  predictLastFlick,
-} from '../../src/components/Randomiser';
+import { forTestingPurposesOnly } from '../../src/components/Randomiser';
+
+const { flickThroughArray, flickSlowDown, predictLastFlick } = forTestingPurposesOnly;
 
 const sleepFunc = jest.fn(() => Promise.resolve());
 

--- a/test/randomizer/flickThroughArray.test.ts
+++ b/test/randomizer/flickThroughArray.test.ts
@@ -1,0 +1,70 @@
+import {
+  flickSlowDown,
+  flickThroughArray,
+  predictLastFlick,
+} from '../../src/components/Randomiser';
+
+describe('flickSlowDown', () => {
+  it('should return values that get exponitally bigger', () => {
+    const duration = 900;
+    const pauseDurations = [30];
+
+    let timeTaken = 0;
+    let overThreshold = false;
+    let gettingBigger = false;
+
+    while (timeTaken < duration) {
+      pauseDurations.push(
+        flickSlowDown(pauseDurations[pauseDurations.length - 1], timeTaken, duration)
+      );
+      timeTaken += pauseDurations[pauseDurations.length - 1];
+      if (pauseDurations[pauseDurations.length - 1] > pauseDurations[pauseDurations.length - 2]) {
+        if (overThreshold) {
+          gettingBigger = true;
+        } else overThreshold = true;
+      } else if (overThreshold) {
+        gettingBigger = false;
+        break;
+      }
+    }
+    expect(gettingBigger && overThreshold).toBe(true);
+  });
+});
+
+describe('flickThroughArray', () => {
+  it('should only return values inside the array', async () => {
+    const array = [1, 2, 3, 4, 5];
+    const duration = 200;
+    const pauseDuration = 10;
+    const callback = jest.fn();
+
+    const result = await flickThroughArray(array, { duration, pauseDuration, callback });
+    expect(array).toContain(result);
+    expect(callback).toBeCalled();
+  });
+
+  it('should throw an error if pauseDuration is 0', async () => {
+    const array = [1, 2, 3, 4, 5];
+    const duration = 200;
+    const pauseDuration = 0;
+    const callback = jest.fn();
+
+    const promise = flickThroughArray(array, { duration, pauseDuration, callback });
+    expect(promise).rejects.toThrow();
+    expect(callback).toBeCalledTimes(0);
+  });
+});
+
+describe('predictLastFlick', () => {
+  it('should return the last flick of flickThroughArray', async () => {
+    const array = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    const duration = 200;
+    const pauseDuration = 10;
+    const callback = jest.fn();
+
+    const result = await predictLastFlick(array, { duration, pauseDuration });
+    const flickResult = await flickThroughArray(array, { duration, pauseDuration, callback });
+
+    expect(result).toEqual(flickResult);
+  });
+});


### PR DESCRIPTION
When I was testing the new randomizer on my phone yesterday the performance was very poor. I tracked it down to be the 'handleSetItem' function causing the slowdown. It was being called anytime a new value was flicked through which is, as far as I understand it, unnecessary because we only care about the last value. So I fixed that and it runs a lot smoother on phone or desktop.

I also simplified the logic by removing recursion which was elegant in the beginning but got cluttered pretty quick .

And finally I added some tests to make it more robust.