### PR TITLE
fixed bar disappering from screen on desktop (#44)

### DIFF
--- a/src/components/StepMenu.tsx
+++ b/src/components/StepMenu.tsx
@@ -212,7 +212,7 @@ const VerticalLinearStepper = () => {
               sx={{
                 display: 'flex',
                 width: '100%',
-                paddingLeft: '70vw',
+                marginLeft: '75%',
               }}
             >
               <span>Bar:&nbsp;</span>


### PR DESCRIPTION
I ended up setting `marginLeft` to a percent value since `flex-end` as I commented in the issue would align it to the end of the container and I guess you want it to be aligned with the end of the Start Over button instead.